### PR TITLE
Updates to work with new FastLapackInterface

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -1,0 +1,20 @@
+name: Documenter
+on:
+    push:
+        branches: [main]
+    pull_request:
+
+jobs:
+    Documenter:
+      name: Documentation
+      runs-on: ubuntu-latest
+      steps:
+          - uses: julia-actions/setup-julia@v1
+            with:
+                version: '1.8.0'
+          - uses: actions/checkout@v2
+          - uses: julia-actions/julia-buildpkg@latest
+          - uses: julia-actions/julia-docdeploy@latest
+            env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,14 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+    tags: '*'
+  pull_request:
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.version == 'nightly' }}
+    strategy:
+      matrix:
+        version:
+          - '1.6'
+          - '1.8.0'
+          - 'nightly'
+        os:
+          - ubuntu-latest
+          - macOS-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v1
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-uploadcodecov@latest
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -9,4 +9,4 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 julia = "1.6.5"
-FastLapackInterface = "0.1.3"
+FastLapackInterface = "^1"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,56 @@
+# Based on documentation of DFControl and DFTK
+using LibGit2: LibGit2
+using Pkg: Pkg
+
+# To manually generate the docs:
+# Run "julia make.jl" to generate the docs
+
+# Set to true to disable some checks and cleanup
+DEBUG = false
+
+# Where to get files from and where to build them
+SRCPATH = joinpath(@__DIR__, "src")
+BUILDPATH = joinpath(@__DIR__, "build")
+ROOTPATH = joinpath(@__DIR__, "..")
+CONTINUOUS_INTEGRATION = get(ENV, "CI", nothing) == "true"
+
+JLDEPS = [Pkg.PackageSpec(;
+                          url = "https://github.com/louisponet/PolynomialMatrixEquations.jl.git",
+                          rev = LibGit2.head(ROOTPATH))]
+
+# Setup julia dependencies for docs generation if not yet done
+Pkg.activate(@__DIR__)
+Pkg.develop(Pkg.PackageSpec(; path = ROOTPATH))
+Pkg.instantiate()
+
+# Import packages for docs generation
+using PolynomialMatrixEquations
+using LinearAlgebra
+using LinearAlgebra: LAPACK
+using Documenter
+
+DocMeta.setdocmeta!(PolynomialMatrixEquations, :DocTestSetup,
+                    quote
+                        using PolynomialMatrixEquations, LinearAlgebra
+                    end)
+
+# Generate the docs in BUILDPATH
+makedocs(; modules = [PolynomialMatrixEquations],
+         format = Documenter.HTML(
+                                  # Use clean URLs, unless built as a "local" build
+                                  ; prettyurls = CONTINUOUS_INTEGRATION,
+                                  canonical = "https://louisponet.github.io/PolynomialMatrixEquations.jl/stable/",
+                                  assets = ["assets/favicon.ico"]),
+         sitename = "PolynomialMatrixEquations.jl", authors = "Michel Juillard, Louis Ponet",
+         linkcheck_ignore = [
+                             # Ignore links that point to GitHub's edit pages, as they redirect to the
+                             # login screen and cause a warning:
+                             r"https://github.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)/edit(.*)"],
+         pages = ["Home" => "index.md"])
+
+# Deploy docs to gh-pages branch
+deploydocs(; repo = "github.com/louisponet/PolynomialMatrixEquations.jl.git", devbranch = "main")
+
+if !CONTINUOUS_INTEGRATION
+    println("\nDocs generated, try $(joinpath(BUILDPATH, "index.html"))")
+end

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,3 @@
+# PolynomialMatrixEquations.jl
+
+Documentation for PolynomialMatrixEquations.jl

--- a/src/CyclicReduction.jl
+++ b/src/CyclicReduction.jl
@@ -82,24 +82,23 @@ function cyclic_reduction!(x::AbstractMatrix{Float64},
         ws.a1copy .= a1
         lu_t = LU(factorize!(ws.linsolve_ws, ws.a1copy)...)
         ldiv!(lu_t, ws.m1)
-        gemm!('N','N',-1.0,ws.m2,ws.m1,0.0,ws.m)
         
-        @simd for i in eachindex(a1)
-            a1[i] += m02[i] + m20[i]
-        end
+        gemm!('N','N',-1.0,m2,m1,0.0,m)
+        
+        a1 .+= m02 .+ m20
         m1_a0 .= m00
         m1_a2 .= m22
         m2_a0 .= m00
         m2_a2 .= m22
         if any(isinf, m) || any(isnan,m)
-            fill!(x,NaN)
+            fill!(x, NaN)
             if norm(m1_a0) < Inf
                 throw(UndeterminateSystemException())
             else
                 throw(UnstableSystemException())
             end
         end
-        ws.ahat1 .+=m20
+        ws.ahat1 .+= m20
         crit = norm(m1_a0,1)
         if crit < cvg_tol
         # keep iterating until condition on a2 is met

--- a/src/CyclicReduction.jl
+++ b/src/CyclicReduction.jl
@@ -6,7 +6,7 @@ mutable struct CyclicReductionWs
     linsolve_ws::LUWs
     ahat1::Matrix{Float64}
     a1copy::Matrix{Float64}
-    m::Matrix{Float64,}
+    m::Matrix{Float64}
     m1::Matrix{Float64}
     m2::Matrix{Float64}
     info::Int
@@ -83,7 +83,7 @@ function cyclic_reduction!(x::AbstractMatrix{Float64},
         lu_t = LU(factorize!(ws.linsolve_ws, ws.a1copy)...)
         ldiv!(lu_t, ws.m1)
         
-        gemm!('N','N',-1.0,m2,m1,0.0,m)
+        mul!(m, m2, m1, -1.0, 0.0)
         
         a1 .+= m02 .+ m20
         m1_a0 .= m00

--- a/src/GeneralizedSchurDecompositionSolver.jl
+++ b/src/GeneralizedSchurDecompositionSolver.jl
@@ -47,6 +47,7 @@ function gs_solver!(ws::GsSolverWs, d::Matrix{Float64},e::Matrix{Float64}, n1::I
     elseif nstable > n1
         throw(UndeterminateSystemException())
     end
+    
     transpose!(ws.g2, view(ws.schurws.vsr, 1:nstable, nstable+1:n))
     ws.Z22 .= view(ws.schurws.vsr,nstable+1:n, nstable+1:n)
     lu_t = LU(factorize!(ws.luws2, ws.Z22)...)
@@ -62,6 +63,6 @@ function gs_solver!(ws::GsSolverWs, d::Matrix{Float64},e::Matrix{Float64}, n1::I
     ws.g1 .= view(ws.schurws.vsr,1:nstable, 1:nstable)
     lu_t = LU(factorize!(ws.luws1, ws.g1)...)
     ldiv!(lu_t', ws.tmp3)
-    gemm!('T','T',1.0,ws.tmp2,ws.tmp3,0.0,ws.g1)
+    mul!(ws.g1, ws.tmp2', ws.tmp3', 1.0, 0.0)
 end
 

--- a/src/GeneralizedSchurDecompositionSolver.jl
+++ b/src/GeneralizedSchurDecompositionSolver.jl
@@ -1,86 +1,54 @@
-using FastLapackInterface: DggesWs, dgges!
-using FastLapackInterface: LinSolveWs, linsolve_core!
 using LinearAlgebra
 using LinearAlgebra.BLAS
-
+using LinearAlgebra.LAPACK: gges!
 struct GsSolverWs
-    dgges_ws::DggesWs
-    linsolve_ws_11::LinSolveWs
-    linsolve_ws_22::LinSolveWs
-    D11::SubArray{Float64}
-    E11::SubArray{Float64}
-    vsr::Matrix{Float64}
-    Z11::SubArray{Float64}
-    Z12::SubArray{Float64}
-    Z21::SubArray{Float64}
-    Z22::SubArray{Float64}
     tmp1::Matrix{Float64}
     tmp2::Matrix{Float64}
     tmp3::Matrix{Float64}
+    Z22::Matrix{Float64}
     g1::Matrix{Float64}
     g2::Matrix{Float64}
     eigval::Vector{ComplexF64}
     
-    function GsSolverWs(d,e,n1)
-        dgges_ws = DggesWs(Ref{UInt8}('N'), Ref{UInt8}('N'), Ref{UInt8}('N'), e, d)
+    function GsSolverWs(d,n1)
         n = size(d,1)
         n2 = n - n1
-        linsolve_ws_11 = LinSolveWs(n1)
-        linsolve_ws_22 = LinSolveWs(n2)
-        D11 = view(d,1:n1,1:n1)
-        E11 = view(e,1:n1,1:n1)
-        vsr = Matrix{Float64}(undef, n, n)
-        Z11 = view(vsr,1:n1,1:n1)
-        Z12 = view(vsr,1:n1,n1+1:n)
-        Z21 = view(vsr,n1+1:n,1:n1)
-        Z22 = view(vsr,n1+1:n,n1+1:n)
-        tmp1 = Matrix{Float64}(undef, n2, n1)
+        tmp1 = Matrix{Float64}(undef, n1, n1)
         tmp2 = Matrix{Float64}(undef, n1, n1)
         tmp3 = Matrix{Float64}(undef, n1, n1)
+        Z22 = Matrix{Float64}(undef, n2, n2)
         g1 = Matrix{Float64}(undef, n1, n1)
         g2 = Matrix{Float64}(undef, n2, n1)
         eigval = Vector{ComplexF64}(undef, n)
-        new(dgges_ws,linsolve_ws_11, linsolve_ws_22, D11,E11,vsr,Z11,Z12,Z21,Z22,tmp1,tmp2,tmp3,g1,g2, eigval)
+        new(tmp1,tmp2,tmp3,Z22,g1,g2, eigval)
     end
 end
 
-#"""
-#    gs_solver!(ws::GsSolverWs,d::Matrix{Float64},e::Matrix{Float64},n1::Int64,qz_criterium)
-#
-#finds the unique stable solution for the following system:
-#
-#```
-#d \left[\begin{array}{c}I\\g_2\end{array}\right]g_1 = e \left[\begin{array}{c}I\\g_2\end{array}\right]
-#```
-#The solution is returned in ``ws.g1`` and ``ws.g2``
-#"""
-function gs_solver!(ws::GsSolverWs,d::Matrix{Float64},e::Matrix{Float64},n1::Int64,qz_criterium::Float64)
+function gs_solver!(ws::GsSolverWs,schurws::GeneralizedSchurWs, luws::LUWs, d::Matrix{Float64},e::Matrix{Float64}, n1::Int64, qz_criterium::Float64=1 + 1e-6)
 
-    try
-        dgges!('N', 'V', e, d, zeros(1,1), ws.vsr, ws.eigval, ws.dgges_ws)
-    catch err
-        if err.error_nbr == size(e,1) + 2
-            println("Warning: DGGES reports error $(err.error_nbr)")
-        else
-            rethrow(err)
-        end
-    end
-    nstable = ws.dgges_ws.sdim[]
-    
+    gges!(schurws, 'N', 'V', e, d; select = (αr, αi, β) -> αr^2 + αi^2 < qz_criterium * β^2)
+    nstable = schurws.sdim[]::Int
+    n = size(d, 1)
     if nstable < n1
         throw(UnstableSystemException())
     elseif nstable > n1
         throw(UndeterminateSystemException())
     end
-    ws.g2 .= ws.Z12'
-    linsolve_core!(ws.Z22', ws.g2, ws.linsolve_ws_22)
+    transpose!(ws.g2, view(schurws.vsr, 1:nstable, nstable+1:n))
+    ws.Z22 .= view(schurws.vsr,nstable+1:n, nstable+1:n)
+    lu_t = LU(factorize!(luws, ws.Z22)...)
+    ldiv!(lu_t', ws.g2)
     lmul!(-1.0,ws.g2)
-    ws.tmp2 .= ws.Z11'
-    ws.D11 .= view(d,1:nstable,1:nstable)
-    linsolve_core!(ws.D11', ws.tmp2, ws.linsolve_ws_11)
-    ws.E11 .= view(e,1:nstable,1:nstable)
-    ws.tmp3 .= ws.E11'
-    linsolve_core!(ws.Z11', ws.tmp3, ws.linsolve_ws_11)
+    
+    transpose!(ws.tmp2, view(schurws.vsr, 1:nstable, 1:nstable))
+    ws.g1 .= view(d, 1:nstable,1:nstable)
+    lu_t = LU(factorize!(luws, ws.g1)...)
+    ldiv!(lu_t', ws.tmp2)
+   
+    transpose!(ws.tmp3, view(e,1:nstable,1:nstable))
+    ws.g1 .= view(schurws.vsr,1:nstable, 1:nstable)
+    lu_t = LU(factorize!(luws, ws.g1)...)
+    ldiv!(lu_t', ws.tmp3)
     gemm!('T','T',1.0,ws.tmp2,ws.tmp3,0.0,ws.g1)
 end
 

--- a/src/GeneralizedSchurDecompositionSolver.jl
+++ b/src/GeneralizedSchurDecompositionSolver.jl
@@ -28,6 +28,16 @@ struct GsSolverWs
     end
 end
 
+#"""
+#    gs_solver!(ws::GsSolverWs,d::Matrix{Float64},e::Matrix{Float64},n1::Int64,qz_criterium)
+#
+#finds the unique stable solution for the following system:
+#
+#```
+#d \left[\begin{array}{c}I\\g_2\end{array}\right]g_1 = e \left[\begin{array}{c}I\\g_2\end{array}\right]
+#```
+#The solution is returned in ``ws.g1`` and ``ws.g2``
+#"""
 function gs_solver!(ws::GsSolverWs, d::Matrix{Float64},e::Matrix{Float64}, n1::Int64, qz_criterium::Float64=1 + 1e-6)
     gges!(ws.schurws, 'N', 'V', e, d; select = (αr, αi, β) -> αr^2 + αi^2 < qz_criterium * β^2)
     nstable = ws.schurws.sdim[]::Int

--- a/src/GeneralizedSchurDecompositionSolver.jl
+++ b/src/GeneralizedSchurDecompositionSolver.jl
@@ -53,9 +53,9 @@ function gs_solver!(ws::GsSolverWs, d::Matrix{Float64},e::Matrix{Float64}, n1::I
     lu_t = LU(factorize!(ws.luws1, view(d, 1:nstable,1:nstable))...)
     ldiv!(lu_t', ws.tmp1)
 
-    transpose!(ws.tmp3, view(e,1:nstable,1:nstable))
+    transpose!(ws.tmp2, view(e,1:nstable,1:nstable))
     lu_t = LU(factorize!(ws.luws1, view(ws.schurws.vsr,1:nstable, 1:nstable))...)
-    ldiv!(lu_t', ws.tmp3)
-    mul!(ws.g1, ws.tmp2', ws.tmp3', 1.0, 0.0)
+    ldiv!(lu_t', ws.tmp2)
+    mul!(ws.g1, ws.tmp1', ws.tmp2', 1.0, 0.0)
 end
 

--- a/src/GeneralizedSchurDecompositionSolver.jl
+++ b/src/GeneralizedSchurDecompositionSolver.jl
@@ -8,46 +8,49 @@ struct GsSolverWs
     Z22::Matrix{Float64}
     g1::Matrix{Float64}
     g2::Matrix{Float64}
-    eigval::Vector{ComplexF64}
+    luws1::LUWs
+    luws2::LUWs
+    schurws::GeneralizedSchurWs{Float64}
     
     function GsSolverWs(d,n1)
         n = size(d,1)
         n2 = n - n1
-        tmp1 = Matrix{Float64}(undef, n1, n1)
-        tmp2 = Matrix{Float64}(undef, n1, n1)
-        tmp3 = Matrix{Float64}(undef, n1, n1)
-        Z22 = Matrix{Float64}(undef, n2, n2)
-        g1 = Matrix{Float64}(undef, n1, n1)
-        g2 = Matrix{Float64}(undef, n2, n1)
-        eigval = Vector{ComplexF64}(undef, n)
-        new(tmp1,tmp2,tmp3,Z22,g1,g2, eigval)
+        tmp1 = similar(d, n1, n1)
+        tmp2 = similar(d, n1, n1)
+        tmp3 = similar(d, n1, n1)
+        Z22  = similar(d, n2, n2)
+        g1   = similar(d, n1, n1)
+        g2   = similar(d, n2, n1)
+        luws1 = LUWs(tmp1)
+        luws2 = LUWs(Z22)
+        schurws = GeneralizedSchurWs(d)
+        new(tmp1,tmp2,tmp3,Z22,g1,g2, luws1, luws2, schurws)
     end
 end
 
-function gs_solver!(ws::GsSolverWs,schurws::GeneralizedSchurWs, luws::LUWs, d::Matrix{Float64},e::Matrix{Float64}, n1::Int64, qz_criterium::Float64=1 + 1e-6)
-
-    gges!(schurws, 'N', 'V', e, d; select = (αr, αi, β) -> αr^2 + αi^2 < qz_criterium * β^2)
-    nstable = schurws.sdim[]::Int
+function gs_solver!(ws::GsSolverWs, d::Matrix{Float64},e::Matrix{Float64}, n1::Int64, qz_criterium::Float64=1 + 1e-6)
+    gges!(ws.schurws, 'N', 'V', e, d; select = (αr, αi, β) -> αr^2 + αi^2 < qz_criterium * β^2)
+    nstable = ws.schurws.sdim[]::Int
     n = size(d, 1)
     if nstable < n1
         throw(UnstableSystemException())
     elseif nstable > n1
         throw(UndeterminateSystemException())
     end
-    transpose!(ws.g2, view(schurws.vsr, 1:nstable, nstable+1:n))
-    ws.Z22 .= view(schurws.vsr,nstable+1:n, nstable+1:n)
-    lu_t = LU(factorize!(luws, ws.Z22)...)
+    transpose!(ws.g2, view(ws.schurws.vsr, 1:nstable, nstable+1:n))
+    ws.Z22 .= view(ws.schurws.vsr,nstable+1:n, nstable+1:n)
+    lu_t = LU(factorize!(ws.luws2, ws.Z22)...)
     ldiv!(lu_t', ws.g2)
     lmul!(-1.0,ws.g2)
     
-    transpose!(ws.tmp2, view(schurws.vsr, 1:nstable, 1:nstable))
+    transpose!(ws.tmp2, view(ws.schurws.vsr, 1:nstable, 1:nstable))
     ws.g1 .= view(d, 1:nstable,1:nstable)
-    lu_t = LU(factorize!(luws, ws.g1)...)
+    lu_t = LU(factorize!(ws.luws1, ws.g1)...)
     ldiv!(lu_t', ws.tmp2)
    
     transpose!(ws.tmp3, view(e,1:nstable,1:nstable))
-    ws.g1 .= view(schurws.vsr,1:nstable, 1:nstable)
-    lu_t = LU(factorize!(luws, ws.g1)...)
+    ws.g1 .= view(ws.schurws.vsr,1:nstable, 1:nstable)
+    lu_t = LU(factorize!(ws.luws1, ws.g1)...)
     ldiv!(lu_t', ws.tmp3)
     gemm!('T','T',1.0,ws.tmp2,ws.tmp3,0.0,ws.g1)
 end

--- a/src/GeneralizedSchurDecompositionSolver.jl
+++ b/src/GeneralizedSchurDecompositionSolver.jl
@@ -4,8 +4,6 @@ using LinearAlgebra.LAPACK: gges!
 struct GsSolverWs
     tmp1::Matrix{Float64}
     tmp2::Matrix{Float64}
-    tmp3::Matrix{Float64}
-    Z22::Matrix{Float64}
     g1::Matrix{Float64}
     g2::Matrix{Float64}
     luws1::LUWs
@@ -17,14 +15,12 @@ struct GsSolverWs
         n2 = n - n1
         tmp1 = similar(d, n1, n1)
         tmp2 = similar(d, n1, n1)
-        tmp3 = similar(d, n1, n1)
-        Z22  = similar(d, n2, n2)
         g1   = similar(d, n1, n1)
         g2   = similar(d, n2, n1)
         luws1 = LUWs(tmp1)
-        luws2 = LUWs(Z22)
+        luws2 = LUWs(n2)
         schurws = GeneralizedSchurWs(d)
-        new(tmp1,tmp2,tmp3,Z22,g1,g2, luws1, luws2, schurws)
+        new(tmp1,tmp2,g1,g2, luws1, luws2, schurws)
     end
 end
 
@@ -48,20 +44,17 @@ function gs_solver!(ws::GsSolverWs, d::Matrix{Float64},e::Matrix{Float64}, n1::I
         throw(UndeterminateSystemException())
     end
     transpose!(ws.g2, view(ws.schurws.vsr, 1:nstable, nstable+1:n))
-    ws.Z22 .= view(ws.schurws.vsr,nstable+1:n, nstable+1:n)
-    lu_t = LU(factorize!(ws.luws2, ws.Z22)...)
+    lu_t = LU(factorize!(ws.luws2, view(ws.schurws.vsr,nstable+1:n, nstable+1:n))...)
     ldiv!(lu_t', ws.g2)
     lmul!(-1.0,ws.g2)
     
-    transpose!(ws.tmp2, view(ws.schurws.vsr, 1:nstable, 1:nstable))
-    ws.g1 .= view(d, 1:nstable,1:nstable)
-    lu_t = LU(factorize!(ws.luws1, ws.g1)...)
-    ldiv!(lu_t', ws.tmp2)
+    transpose!(ws.tmp1, view(ws.schurws.vsr, 1:nstable, 1:nstable))
+    lu_t = LU(factorize!(ws.luws1, view(d, 1:nstable,1:nstable))...)
+    ldiv!(lu_t', ws.tmp1)
    
-    transpose!(ws.tmp3, view(e,1:nstable,1:nstable))
-    ws.g1 .= view(ws.schurws.vsr,1:nstable, 1:nstable)
-    lu_t = LU(factorize!(ws.luws1, ws.g1)...)
-    ldiv!(lu_t', ws.tmp3)
-    gemm!('T','T',1.0,ws.tmp2,ws.tmp3,0.0,ws.g1)
+    transpose!(ws.tmp2, view(e,1:nstable,1:nstable))
+    lu_t = LU(factorize!(ws.luws1, view(ws.schurws.vsr,1:nstable, 1:nstable))...)
+    ldiv!(lu_t', ws.tmp2)
+    gemm!('T','T',1.0,ws.tmp1,ws.tmp2,0.0,ws.g1)
 end
 

--- a/src/PolynomialMatrixEquations.jl
+++ b/src/PolynomialMatrixEquations.jl
@@ -4,8 +4,8 @@ struct UnstableSystemException <: Exception end
 struct UndeterminateSystemException <: Exception end
 export UnstableSystemException, UndeterminateSystemException
 using FastLapackInterface
-# include("CyclicReduction.jl")
-# export CyclicReductionWs, cyclic_reduction!, cyclic_reduction_check
+include("CyclicReduction.jl")
+export CyclicReductionWs, cyclic_reduction!, cyclic_reduction_check
 
 include("GeneralizedSchurDecompositionSolver.jl")
 export GsSolverWs, gs_solver!

--- a/src/PolynomialMatrixEquations.jl
+++ b/src/PolynomialMatrixEquations.jl
@@ -3,9 +3,9 @@ module PolynomialMatrixEquations
 struct UnstableSystemException <: Exception end
 struct UndeterminateSystemException <: Exception end
 export UnstableSystemException, UndeterminateSystemException
-
-include("CyclicReduction.jl")
-export CyclicReductionWs, cyclic_reduction!, cyclic_reduction_check
+using FastLapackInterface
+# include("CyclicReduction.jl")
+# export CyclicReductionWs, cyclic_reduction!, cyclic_reduction_check
 
 include("GeneralizedSchurDecompositionSolver.jl")
 export GsSolverWs, gs_solver!

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ numberundeterminate = 0
 numberunstable = 0
 
 qz_criterium = 1 + 1e-6
-@testset "GsSolverWs" begin
+@testset "all" begin
     Random.seed!(123)
     ncases = 20
     n=10
@@ -33,32 +33,32 @@ qz_criterium = 1 + 1e-6
         a1 = Matrix([d[:, 1:nstable] -e[:, (nstable+1):n]])
         a2 = Matrix([zeros(n, nstable) d[:, (nstable+1):n]])
 
-        # x = zeros(n, n)
-        # ws2 = CyclicReductionWs(n)
-        # cyclic_reduction!(x, a0, a1, a2, ws2, 1e-8, 50)
-        # @test isapprox(a0 + a1*x + a2*x*x, zeros(n, n); atol = 1e-12)
+        x = zeros(n, n)
+        ws2 = CyclicReductionWs(n)
+        cyclic_reduction!(x, a0, a1, a2, ws2, 1e-8, 50)
+        @test isapprox(a0 + a1*x + a2*x*x, zeros(n, n); atol = 1e-12)
 
-        # nstable1 = nstable + 1
-        # @test_throws UnstableSystemException gs_solver!(ws1, d, e, nstable + 1, qz_criterium)
+        nstable1 = nstable + 1
+        @test_throws UnstableSystemException gs_solver!(ws1, d, e, nstable + 1, qz_criterium)
         
-        # a0 = Matrix([-e[:, 1:nstable1] zeros(n, n-nstable1)])
-        # a1 = Matrix([d[:, 1:nstable1] -e[:, (nstable1+1):n]])
-        # a2 = Matrix([zeros(n, nstable1) d[:, (nstable1+1):n]])
+        a0 = Matrix([-e[:, 1:nstable1] zeros(n, n-nstable1)])
+        a1 = Matrix([d[:, 1:nstable1] -e[:, (nstable1+1):n]])
+        a2 = Matrix([zeros(n, nstable1) d[:, (nstable1+1):n]])
 
-        # x = zeros(n, n)
-        # ws2 = CyclicReductionWs(n)
+        x = zeros(n, n)
+        ws2 = CyclicReductionWs(n)
 
-        # @test_throws UnstableSystemException cyclic_reduction!(x, a0, a1, a2, ws2, 1e-8, 50)
+        @test_throws UnstableSystemException cyclic_reduction!(x, a0, a1, a2, ws2, 1e-8, 50)
 
-        # nstable1 = nstable - 1
-        # @test_throws UndeterminateSystemException gs_solver!(ws1, d, e, nstable1, qz_criterium)
+        nstable1 = nstable - 1
+        @test_throws UndeterminateSystemException gs_solver!(ws1, d, e, nstable1, qz_criterium)
 
-        # a0 = Matrix([-e[:, 1:nstable1] zeros(n, n-nstable1)])
-        # a1 = Matrix([d[:, 1:nstable1] -e[:, (nstable1+1):n]])
-        # a2 = Matrix([zeros(n, nstable1) d[:, (nstable1+1):n]])
+        a0 = Matrix([-e[:, 1:nstable1] zeros(n, n-nstable1)])
+        a1 = Matrix([d[:, 1:nstable1] -e[:, (nstable1+1):n]])
+        a2 = Matrix([zeros(n, nstable1) d[:, (nstable1+1):n]])
 
-        # x = zeros(n, n)
-        # ws2 = CyclicReductionWs(n)
-        # @test_throws UndeterminateSystemException cyclic_reduction!(x, a0, a1, a2, ws2, 1e-8, 50)
+        x = zeros(n, n)
+        ws2 = CyclicReductionWs(n)
+        @test_throws UndeterminateSystemException cyclic_reduction!(x, a0, a1, a2, ws2, 1e-8, 50)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using LinearAlgebra
 using PolynomialMatrixEquations
-using PolynomialMatrixEquations.FastLapackInterface
 using Random
 using Test
 
@@ -10,19 +9,16 @@ numberundeterminate = 0
 numberunstable = 0
 
 qz_criterium = 1 + 1e-6
-@testset "GsSolverWs" begin 
+@testset "GsSolverWs" begin
     Random.seed!(123)
     ncases = 20
     n=10
-    d_origs = [randn(n, n) for i =1:ncases]
-    e_origs = [randn(n, n) for i =1:ncases]
-    luwss = [LUWs(randn(5,5)) for i = 1:ncases]
+    d_origs = [randn(n,n) for i = 1:ncases]
+    e_origs = [randn(n,n) for i = 1:ncases]
     for i = 1:ncases
         println("Test $i")
         d_orig = d_origs[i]
         e_orig = e_origs[i]
-        luws = luwss[i]
-        schurws = GeneralizedSchurWs(randn(5,5))
         F = schur(e_orig, d_orig)
         eigenvalues = F.α ./ F.β
         nstable = count(abs.(eigenvalues) .< 1+1e-6)
@@ -30,12 +26,12 @@ qz_criterium = 1 + 1e-6
         d = copy(d_orig)
         e = copy(e_orig)
         ws1 = GsSolverWs(d, nstable)
-        @time gs_solver!(ws1, schurws, luws, d, e, nstable, qz_criterium)
+        gs_solver!(ws1, d, e, nstable, qz_criterium)
         @test d_orig*[I(nstable); ws1.g2]*ws1.g1 ≈ e_orig*[I(nstable); ws1.g2]
 
-        # a0 = Matrix([-e[:, 1:nstable] zeros(n, n-nstable)])
-        # a1 = Matrix([d[:, 1:nstable] -e[:, (nstable+1):n]])
-        # a2 = Matrix([zeros(n, nstable) d[:, (nstable+1):n]])
+        a0 = Matrix([-e[:, 1:nstable] zeros(n, n-nstable)])
+        a1 = Matrix([d[:, 1:nstable] -e[:, (nstable+1):n]])
+        a2 = Matrix([zeros(n, nstable) d[:, (nstable+1):n]])
 
         # x = zeros(n, n)
         # ws2 = CyclicReductionWs(n)


### PR DESCRIPTION
This PR includes some updates that make it work with FastLapackInterface 1.2.5, and also some improvements to performance here and there. For example, `gs_solver!` now only uses 1/4th of the time as before and has 0 allocations.